### PR TITLE
Change timeout waiting for URL's  not responding

### DIFF
--- a/vendors/guzzlehttp/guzzle/src/Guzzle/Http/Curl/CurlHandle.php
+++ b/vendors/guzzlehttp/guzzle/src/Guzzle/Http/Curl/CurlHandle.php
@@ -58,7 +58,7 @@ class CurlHandle
         // Array of default cURL options.
         $curlOptions = array(
             CURLOPT_URL            => $url,
-            CURLOPT_CONNECTTIMEOUT => 150,
+            CURLOPT_CONNECTTIMEOUT => 5,
             CURLOPT_RETURNTRANSFER => false,
             CURLOPT_HEADER         => false,
             CURLOPT_PORT           => $request->getPort(),


### PR DESCRIPTION
Avoid timeouts causing database connection timeouts while curl is waiting for curl to do it's job. See https://community.elgg.org/plugins/1592751/releases/2.2.1 which is in fact not a HypeWall plugin issue.

This happens more than you would expect, depending on server configuration (ihaving nfinite loops)